### PR TITLE
chore: bump version and update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "imentor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "imentor",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.7",
@@ -16,10 +16,11 @@
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^6.0.2",
-        "eslint": "^9.7.0",
+        "eslint": "^9.39.4",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "form-data": "4.0.6",
         "postcss": "^8.5.15",
         "vite": "^8.0.16"
       },
@@ -2136,16 +2137,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imentor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "engines": {
@@ -21,12 +21,13 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^6.0.2",
-    "eslint": "^9.7.0",
+    "eslint": "^9.39.4",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "postcss": "^8.5.15",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "form-data": "4.0.6"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Bump the app version to 1.0.1 and update the dependency lockfile after running npm install.